### PR TITLE
Respect objectMode:true for output streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ $ node main
 * Any number of output streams, each with configurable minimum log-levels
 * Fast short-circuit where no loggers are configured for the log-level, effectively making log statements a noop where they don't output
 * Sub-logger to split a logger for grouping types of events, such as individual HTTP request
+* Object-logging (i.e. not automatically stringified) if you pass an `objectMode:true` stream for output.
 
 ## API
 
@@ -98,6 +99,8 @@ Sub-loggers can even be split in to sub-sub loggers, the rabbit hole is ~bottoml
 ### bole.output()
 
 Add outputs for application-wide logging, accepts either an object for defining a single output or an array of objects defining multiple outputs. Each output requires only a `'level'` and a `'stream'`, where the *level* defines the *minimum* debug level to print to this stream and the *stream* is any `WritableStream` that accepts a `.write()` method.
+
+If you pass in a stream with `objectMode` set to `true` then you will receive the raw log objects rather than their stringified versions.
 
 ```js
 bole.output([

--- a/bole.js
+++ b/bole.js
@@ -34,7 +34,7 @@ function levelLogger (level, name) {
         }
       , k
       , i = 0
-      , s
+      , stringified
 
     if (is.isError(inp)) {
       if (arguments.length > 1)
@@ -69,10 +69,16 @@ function levelLogger (level, name) {
       out.message = format.apply(null, arguments)
     }
 
-    s = stringify(out) + '\n'
 
-    for (; i < outputs.length; i++)
-      outputs[i].write(s)
+    for (; i < outputs.length; i++) {
+      if (outputs[i]._readableState && outputs[i]._readableState.objectMode === true) {
+        outputs[i].write(out)
+      } else {
+        if (!stringified) // lazy stringify
+          stringified = stringify(out) + '\n'
+        outputs[i].write(stringified)
+      }
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -17,13 +17,14 @@
     "url": "https://github.com/rvagg/bole.git"
   },
   "dependencies": {
-    "json-stringify-safe": "~5.0.0",
-    "individual": "~2.0.0",
-    "core-util-is": "~1.0.1"
+    "core-util-is": ">=1.0.1 <1.1.0-0",
+    "individual": ">=3.0.0 <3.1.0-0",
+    "json-stringify-safe": ">=5.0.0 <5.1.0-0"
   },
   "devDependencies": {
-    "tape": "~2.13.1",
-    "bl": "~0.8.0",
-    "hyperquest": "~0.3.0"
+    "bl": ">=0.9.3 <0.10.0-0",
+    "hyperquest": ">=1.0.1 <1.1.0-0",
+    "list-stream": ">=1.0.0 <1.1.0-0",
+    "tape": ">=3.0.3 <3.1.0-0"
   }
 }


### PR DESCRIPTION
closes #2

@gagle please review.

If you pass an object stream then it'll stream objects rather than stringifying, no additional options needed on bole's end.

I believe this _should_ be a minor bump, unfortunately though you can use object streams already and it'll be giving you the stringified versions but this will break that and give you the object versions. Perhaps, just in case someone is doing that, this should be a major bump.