### PR TITLE
Log errors and objects

### DIFF
--- a/bole.js
+++ b/bole.js
@@ -124,13 +124,24 @@ function levelLogger (level, name) {
       if (!(message = format(inp, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16)))
         message = undefined
     } else {
-      if (!(message = format(a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16)))
-        message = undefined
+      if (inp instanceof Error) {
+        if (typeof a2 === 'object') {
+          objectToOut(a2, out)
+          errorToOut(inp, out)
+          if (!(message = format(a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16)))
+            message = undefined
+        } else {
+          errorToOut(inp, out)
+          if (!(message = format(a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16)))
+            message = undefined
+        }
+      } else {
+        if (!(message = format(a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16)))
+          message = undefined
+      }
       if (typeof inp === 'boolean')
         message = String(inp)
-      else if (inp instanceof Error) {
-        errorToOut(inp, out)
-      } else if (typeof inp === 'object') {
+      else if (typeof inp === 'object' && !(inp instanceof Error)) {
         if (inp.method && inp.url && inp.headers && inp.socket)
           requestToOut(inp, out)
         else

--- a/test.js
+++ b/test.js
@@ -485,6 +485,42 @@ test('test object logging', function (t) {
   })
 })
 
+test('test error and object logging', function (t) {
+  t.on('end', bole.reset)
+
+  var sink     = bl()
+    , log      = bole('errobjfmt')
+    , expected = []
+    , err      = new Error('anError')
+
+  bole.output({
+      level      : 'debug'
+    , stream     : sink
+  })
+
+  log.debug(err, { aDebug: 'object' })
+
+  var _expected = mklogobj('errobjfmt', 'debug', {
+      aDebug  : 'object'
+    , message : 'anError'
+    , err     : {
+          name    : 'Error'
+        , message : 'error msg in here'
+        , stack   : 'STACK'
+      }
+  })
+  var expected = safe(JSON.stringify(_expected) + '\n')
+
+  sink.end(function () {
+    var exp = JSON.stringify(expected) + '\n'
+      , act = safe(sink.slice().toString())
+
+    act = act.replace(/("stack":")Error:[^"]+/, '$1STACK')
+
+    t.equal(act, expected)
+    t.end()
+  })
+})
 
 test('test fast time', function (t) {
   t.plan(1)

--- a/test.js
+++ b/test.js
@@ -502,10 +502,9 @@ test('test error and object logging', function (t) {
 
   var _expected = mklogobj('errobjfmt', 'debug', {
       aDebug  : 'object'
-    , message : 'anError'
     , err     : {
           name    : 'Error'
-        , message : 'error msg in here'
+        , message : 'anError'
         , stack   : 'STACK'
       }
   })


### PR DESCRIPTION
We have a requirement to be able to log nice structured errors, but also an object as JSON. This is so that we can use our log analyses tool to filter all of our logs on a property (let's say `userId=1`) and see all the events which pertained to that filter, yet still get structured log messages.

We're providing this PR in case this patch is interesting. If desired I can also update the documentation, however right now I'm rushing to get out of the door and go home.